### PR TITLE
[libbluez-qt] Rewrite BluetoothDevice.

### DIFF
--- a/bluez-qt/bluetoothdevice.h
+++ b/bluez-qt/bluetoothdevice.h
@@ -2,75 +2,112 @@
 #define BLUETOOTHDEVICE_H
 
 #include <QObject>
+#include <QDBusVariant>
 #include <QStringList>
-#include <bluedevice.h>
 
+class OrgBluezDeviceInterface;
 class OrgBluezAudioInterface;
-class OrgBluezInputInterface;
+class QDBusPendingCallWatcher;
+class QDBusObjectPath;
 
 class BluetoothDevice : public QObject
 {
-    Q_OBJECT	
-	Q_PROPERTY(bool connected READ connected NOTIFY connectedChanged);
-	Q_PROPERTY(bool audioConnected READ audioConnected NOTIFY audioConnectedChanged)
-	Q_PROPERTY(bool inputConnected READ inputConnected NOTIFY inputConnectedChanged)
-	Q_PROPERTY(bool trusted READ trusted WRITE setTrusted NOTIFY trustedChanged)
-	Q_PROPERTY(bool paired READ paired NOTIFY pairedChanged)
-	Q_PROPERTY(QStringList profiles READ profiles NOTIFY profilesChanged)
-	Q_PROPERTY(QString alias READ alias)
-	Q_PROPERTY(QString name READ name)
-	Q_PROPERTY(QString address READ address)
-	Q_PROPERTY(QString icon READ icon)
-	Q_PROPERTY(QString path READ path)
+    Q_OBJECT
+    Q_ENUMS(AudioConnectionState)
+    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+    Q_PROPERTY(AudioConnectionState audioConnectionState READ audioConnectionState NOTIFY audioConnectionStateChanged)
+    Q_PROPERTY(QString address READ address NOTIFY addressChanged)
+    Q_PROPERTY(QString name READ name NOTIFY nameChanged)
+    Q_PROPERTY(QString icon READ icon NOTIFY nameChanged)
+    Q_PROPERTY(quint32 classOfDevice READ classOfDevice NOTIFY classOfDeviceChanged)
+    Q_PROPERTY(QStringList profiles READ profiles NOTIFY profilesChanged)
+    Q_PROPERTY(bool paired READ paired NOTIFY pairedChanged)
+    Q_PROPERTY(bool connected READ connected NOTIFY connectedChanged)
+    Q_PROPERTY(bool trusted READ trusted WRITE setTrusted NOTIFY trustedChanged)
+    Q_PROPERTY(QString alias READ alias WRITE setAlias NOTIFY aliasChanged)
+    Q_PROPERTY(bool legacyPairing READ legacyPairing NOTIFY legacyPairingChanged)
 
 public:
-	explicit BluetoothDevice(QDBusObjectPath path = QDBusObjectPath(), QObject *parent = 0);
-	bool paired();
+    enum AudioConnectionState {
+        AudioStateUnknown,
+        AudioConnecting,
+        AudioConnected,
+        AudioDisconnecting,
+        AudioDisconnected
+    };
 
-signals:
-	void connectedChanged(bool isConnected);
-	void audioConnectedChanged(bool isConnected);
-	void inputConnectedChanged(bool isConnected);
-	void propertyChanged(QString name, QVariant value);
-	void profilesChanged(QStringList uuids);
-	void trustedChanged(bool trust);
-	void pairedChanged();
+    explicit BluetoothDevice(QObject *parent = 0);
+    explicit BluetoothDevice(const QDBusObjectPath &path, QObject *parent = 0);
+    ~BluetoothDevice();
+
+    QString path() const;
+    void setPath(const QString &path);
+
+    AudioConnectionState audioConnectionState() const;
+
+    QString address() const;
+
+    QString name() const;
+
+    QString icon() const;
+
+    quint32 classOfDevice() const;
+
+    QStringList profiles() const;
+
+    bool paired() const;
+
+    bool connected() const;
+
+    bool trusted() const;
+    void setTrusted(bool trusted);
+
+    QString alias() const;
+    void setAlias(const QString &alias);
+
+    bool legacyPairing() const;
 
 public slots:
-	void unpair();
-	void connectAudio();
-	void connectAudioSrc();
-	QString connectSerial();
-	void connectInput();
-	void disconnect();
-	void disconnectAudio();
-	bool trusted();
-	void setTrusted(bool trust);
+    void connectAudio();
+    void disconnectAudio();
+    void disconnect();
 
-	QStringList profiles();
-	bool isProfileSupported(QString profile);
+signals:
+    void devicePropertiesChanged();
 
-	///properties:
-	bool connected();
-	bool audioConnected();
-	bool inputConnected();
-	QString alias();
-	QString name();
-	QString address();
-	QString icon();
-	QString path();
+    // deprecated, only used by bluetoothdevicemodel.cpp
+    void propertyChanged(const QString &name, const QVariant &variant);
+
+    void readyChanged();
+    void pathChanged();
+    void audioConnectionStateChanged();
+
+    void addressChanged();
+    void nameChanged();
+    void iconChanged();
+    void classOfDeviceChanged();
+    void profilesChanged();
+    void pairedChanged();
+    void connectedChanged();
+    void trustedChanged();
+    void aliasChanged();
+    void legacyPairingChanged();
 
 private slots:
-	void propertyChanged(QString name,QDBusVariant value);
-	void audioPropertiesChanged(QString name, QDBusVariant value);
-	void inputPropertiesChanged(QString name, QDBusVariant value);
+    void getPropertiesFinished(QDBusPendingCallWatcher *call);
+    void propertyChanged(QString name, QDBusVariant value);
+    void audioPropertyChanged(QString name, QDBusVariant value);
 
 private:
-	void setupProfiles();
+    void init();
+    bool updateProperty(const QString &name, const QVariant &value);
 
-	OrgBluezDeviceInterface *m_device;
-	OrgBluezAudioInterface *audio;
-	OrgBluezInputInterface *input;
+    OrgBluezDeviceInterface *m_device;
+    OrgBluezAudioInterface *m_audio;
+    QVariantMap m_properties;
+    QString m_objectPath;
+    AudioConnectionState m_audioConnectionState;
+    bool m_ready;
 };
 
 #endif // BLUETOOTHDEVICE_H

--- a/bluez-qt/bluetoothdevicemodel.cpp
+++ b/bluez-qt/bluetoothdevicemodel.cpp
@@ -237,7 +237,7 @@ void BluetoothDevicesModel::deviceCreated(QDBusObjectPath devicepath)
 	BluetoothDevice* device = new BluetoothDevice(devicepath,this);
 
 	updateConnected(device->connected());
-	connect(device,SIGNAL(propertyChanged(QString,QVariant)),this,SLOT(devicePropertyChanged(QString,QVariant)));
+    connect(device,SIGNAL(propertyChanged(QString,QVariant)),this,SLOT(devicePropertyChanged(QString,QVariant)));
 
 	beginInsertRows(QModelIndex(),m_devices.size(),m_devices.size());
 	m_devices.append(device);


### PR DESCRIPTION
- Fixed to wait for the result of GetProperties() before returning
  property values. The ready() signal is emitted when properties
  are available.
- Made alias writable
- Added various missing property NOTIFY signals
- Added audioConnectionState and classOfDevice properties
- Fixed to not crash if connectAudio() is called and the device does
  not support A2DP or HSP
- Removed pairing functionality (should be done via the
  org.bluez.Adapter interface instead)
- Removed input and serial connection functionality
