### PR TITLE
[bluez-qt] Support org.bluez.Agent.DisplayPasskey pairing functionality.

### DIFF
--- a/bluez-qt/asyncagent.h
+++ b/bluez-qt/asyncagent.h
@@ -26,6 +26,7 @@ public:
     BluetoothDevice* device() { return m_deviceToPair; }
 
     void authorize(OrgBluezDeviceInterface &device, QString uuid);
+    void displayPasskey(OrgBluezDeviceInterface &device, uint passkey);
     void requestConfirmation(OrgBluezDeviceInterface &device, uint key);
     uint requestPasskey(OrgBluezDeviceInterface &device);
     QString requestPidCode(OrgBluezDeviceInterface &device);
@@ -46,7 +47,8 @@ private:
         AuthorizeAction,
         RequestConfirmationAction,
         RequestPasskeyAction,
-        RequestPidCodeAction
+        RequestPidCodeAction,
+        DisplayPasskeyAction
     };
 
     void initializeDelayedReply(const QDBusObjectPath &path);
@@ -54,6 +56,7 @@ private:
     void notifyConfirmationRequest();
     void notifyPasskeyRequest();
     void notifyPidCodeRequest();
+    void notifyPasskeyDisplay();
 
     BluetoothDevice* m_deviceToPair;
     QDBusMessage m_pendingMessage;
@@ -61,6 +64,7 @@ private:
     Action m_pendingAction;
     QString m_requestAuthorizeUuid;
     uint m_confirmationRequestPasskey;
+    uint m_displayPasskey;
 };
 
 #endif // ASYNCAGENT_H

--- a/bluez-qt/bluetoothagentadaptor.cpp
+++ b/bluez-qt/bluetoothagentadaptor.cpp
@@ -54,7 +54,7 @@ void BluetoothAgentAdaptor::ConfirmModeChange(const QString &mode)
 	agent->confirmModeChange(mode);
 }
 
-void BluetoothAgentAdaptor::DisplayPasskey(const QDBusObjectPath &deviceObject, uint passkey, uint entered)
+void BluetoothAgentAdaptor::DisplayPasskey(const QDBusObjectPath &deviceObject, uint passkey)
 {
 	if(!agent)
 	{
@@ -63,7 +63,7 @@ void BluetoothAgentAdaptor::DisplayPasskey(const QDBusObjectPath &deviceObject, 
 
 	OrgBluezDeviceInterface device("org.bluez", deviceObject.path(), QDBusConnection::systemBus());
 
-	agent->displayPasskey(device, passkey, entered);
+	agent->displayPasskey(device, passkey);
 }
 
 void BluetoothAgentAdaptor::Release()

--- a/bluez-qt/bluetoothagentadaptor.h
+++ b/bluez-qt/bluetoothagentadaptor.h
@@ -31,7 +31,7 @@ public slots:
 	void Authorize(const QDBusObjectPath &device, const QString &uuid);
 	void Cancel();
 	void ConfirmModeChange(const QString &mode);
-	void DisplayPasskey(const QDBusObjectPath &device, uint passkey, uint entered);
+	void DisplayPasskey(const QDBusObjectPath &device, uint passkey);   // 'entered' arg is not actually provided in BlueZ 4.x
 	void Release();
 	void RequestConfirmation(const QDBusObjectPath &device, uint passkey);
 	uint RequestPasskey(const QDBusObjectPath &device);

--- a/bluez-qt/bluetoothbaseagent.cpp
+++ b/bluez-qt/bluetoothbaseagent.cpp
@@ -51,9 +51,8 @@ void BluetoothBaseAgent::confirmModeChange(QString mode)
 	qDebug()<<"mode changed "<<mode;
 }
 
-void BluetoothBaseAgent::displayPasskey(OrgBluezDeviceInterface &device, uint key, uint entered)
+void BluetoothBaseAgent::displayPasskey(OrgBluezDeviceInterface &device, uint key)
 {
-	Q_UNUSED(entered);
 	qDebug()<<"display key "<<device.path()<<" "<<key;
 
 	///create and return back an empty reply:

--- a/bluez-qt/bluetoothbaseagent.h
+++ b/bluez-qt/bluetoothbaseagent.h
@@ -29,7 +29,7 @@ public slots:
 		sendErrorReply("org.bluez.Error.Canceled","The request was canceled");
 	}
 	virtual void confirmModeChange(QString);
-	virtual void displayPasskey(OrgBluezDeviceInterface &device, uint key, uint entered);
+	virtual void displayPasskey(OrgBluezDeviceInterface &device, uint key);
 	virtual void release();
 	virtual void requestConfirmation(OrgBluezDeviceInterface &device, uint key);
 	virtual uint requestPasskey(OrgBluezDeviceInterface &device);


### PR DESCRIPTION
This is required to support pairing requests to/from a device with
KeyboardOnly agent capability. The 'entered' parameter has been removed
from BluetoothAgentAdaptor::DisplayPasskey() as it is not actually
provided by BlueZ 4.101 and so cannot be used with this version.
