### PR TITLE
[bluez-qt] Add module identifier

### DIFF
--- a/declarative/qmldir
+++ b/declarative/qmldir
@@ -1,1 +1,2 @@
+module Bluetooth
 plugin Bluez-qt


### PR DESCRIPTION
A bit generic module name here, but that's how it already is.
