### PR TITLE
[bluez-qt] Check count before removing devices from model

### DIFF
--- a/bluez-qt/bluetoothdevicemodel.h
+++ b/bluez-qt/bluetoothdevicemodel.h
@@ -66,6 +66,7 @@ signals:
 
 private:
 	void updateConnected(bool deviceconnectedStatus);
+	void clearModel();
 
 	bool m_connected;
 	OrgBluezManagerInterface *manager;


### PR DESCRIPTION
On some devices AdapterRemoved may be invoked even if no
devices have been created. As a result base class asserts
on trying to remove non-existing rows from model.