### PR TITLE
[bluez-qt] Add input-related error signals to BluetoothDevice

### DIFF
--- a/bluez-qt/bluetoothdevice.cpp
+++ b/bluez-qt/bluetoothdevice.cpp
@@ -493,7 +493,7 @@ void BluetoothDevice::inputConnectFinished(QDBusPendingCallWatcher *call)
     if (reply.isError()) {
         qWarning() << "org.bluez.Input.Connect() failed for" << address() << ":"
                    << reply.error().name() << reply.error().message();
-        updateInputConnectionState();
+        connectInputError(reply.error().name(), reply.error().message());
     } else {
         setInputConnected(true);
     }
@@ -506,7 +506,7 @@ void BluetoothDevice::inputDisconnectFinished(QDBusPendingCallWatcher *call)
     if (reply.isError()) {
         qWarning() << "org.bluez.Input.Disconnect() failed for" << address() << ":"
                    << reply.error().name() << reply.error().message();
-        updateInputConnectionState();
+        disconnectInputError(reply.error().name(), reply.error().message());
     } else {
         setInputConnected(false);
     }

--- a/bluez-qt/bluetoothdevice.h
+++ b/bluez-qt/bluetoothdevice.h
@@ -107,6 +107,9 @@ signals:
     void aliasChanged();
     void legacyPairingChanged();
 
+    void connectInputError(const QString &error, const QString &errorMessage);
+    void disconnectInputError(const QString &error, const QString &errorMessage);
+
 private slots:
     void getPropertiesFinished(QDBusPendingCallWatcher *call);
     void propertyChanged(QString name, QDBusVariant value);


### PR DESCRIPTION
No need to confirm input connection state when connect/disconnect
fails. Also any failures should be reported by error signals.